### PR TITLE
Add sshpass alternative install instructions link

### DIFF
--- a/ansible/README.md
+++ b/ansible/README.md
@@ -35,6 +35,8 @@ Redhat recommends using the pip install method https://docs.ansible.com/ansible/
 ```
 brew install http://git.io/sshpass.rb
 ```
+**NOTE:** If installing `sshpass` with `brew` is not possible on your system, consult this useful article on [installing sshpass](https://thornelabs.net/posts/ansible-os-x-mavericks-you-must-install-the-sshpass-program.html)
+
 ### Ansible Install  
 ```
 brew install ansible


### PR DESCRIPTION
Homebrew cannot always install sshpass, even from a given url. The provided link is to an article which describes an alternative installation method.

Closes: IBM/community-automation/#13