### PR TITLE
Walt ocs 45ver

### DIFF
--- a/ansible/request-ocs-play/README.md
+++ b/ansible/request-ocs-play/README.md
@@ -3,7 +3,7 @@
 ## Overview
 
 
-- Installs `Openshift Contianer Storage 4.4` by default onto an AWS or VMware OCP cluster.
+- Installs `Openshift Contianer Storage 4.5` by default onto a OCP 4.4.15 or greater AWS or VMware OCP cluster.
 - Creates 3 storageclasses
    - `ocs-storagecluster-ceph-rbd` for block storage
    - `ocs-storagecluster-cephfs` for file storage

--- a/ansible/request-ocs-play/examples/ocs_vars.yml
+++ b/ansible/request-ocs-play/examples/ocs_vars.yml
@@ -1,3 +1,2 @@
-cs_channel: stable-4.4 # OCS changel
 ocs_bastion_setup_dir: ~/setup-files/ocs-setup # Default dir to copy scripts into
 setdefault: true # Set ocs cephfs storageclass as default

--- a/ansible/request-ocs-play/examples/ocs_vars_template.yml
+++ b/ansible/request-ocs-play/examples/ocs_vars_template.yml
@@ -1,2 +1,1 @@
-cs_channel: "@@@VERSION@@@" # OCS changel
 setdefault: "@@@SCDEDAULT@@@" # Set ocs cephfs storageclass as default

--- a/ansible/roles/request-ocs/defaults/main.yml
+++ b/ansible/roles/request-ocs/defaults/main.yml
@@ -1,2 +1,3 @@
+ocsversion: "stable-4.5"
 ocs_bastion_setup_dir: ~/setup-files/ocs-setup
 setdefault: false

--- a/ansible/roles/request-ocs/defaults/main.yml
+++ b/ansible/roles/request-ocs/defaults/main.yml
@@ -1,3 +1,2 @@
-ocs_channel: stable-4.4
 ocs_bastion_setup_dir: ~/setup-files/ocs-setup
 setdefault: false

--- a/ansible/roles/request-ocs/defaults/main.yml
+++ b/ansible/roles/request-ocs/defaults/main.yml
@@ -1,3 +1,3 @@
-ocsversion: "stable-4.5"
+ocs_channel: "stable-4.5"
 ocs_bastion_setup_dir: ~/setup-files/ocs-setup
 setdefault: false

--- a/ansible/roles/request-ocs/files/ocs_install.sh
+++ b/ansible/roles/request-ocs/files/ocs_install.sh
@@ -155,15 +155,17 @@ EOF
 # check if storage classes have been created
 echo "checking for Storage Classes"
 scCounter=0
-until [ $( oc get sc | grep openshift | wc -l) -ge 3 ]
+rc=1
+until [ $rc -eq 0 ]
 do
   echo "Waiting for storage classes to come up: $(date)"
-  oc get sc
   sleep 10
   ((scCounter ++))
   if [ $scCounter -eq 60 ]; then
    exit 1
   fi
+  oc get sc --no-headers | cut -f1 -d' ' | grep noobaa >/dev/null
+  rc=$?
 done
 oc get sc
 echo "setDefault = $setDefault"

--- a/ansible/roles/request-ocs/readme.md
+++ b/ansible/roles/request-ocs/readme.md
@@ -8,7 +8,7 @@ Credits
 Requirements
 ------------
 
- - Running OCP 4.x AWS or VMware cluster is needed
+ - Running OCP 4.4.15 or greater on AWS or VMware cluster is needed
  - Min of 3 worker nodes per cluster.
  - Min sum of worker CPU must be 48 CPUs.
  - oc client installed.
@@ -28,7 +28,7 @@ How to install oc client
 Default parameters set in the defaults/main.yml
 ------------------
 
-    - ocs_channel: stable-4.4 # Channel to pull ocs from, it should match the OCP version.
+    - ocs_channel: stable-4.5 # Channel to pull ocs from, it should match the OCP version.
     - ocs_bastion_setup_dir: ~/setup-files/ocs-setup # Working dir for running the ocs_install.sh
     - setdefault: false  # Make the ocs cephfs storageclass the default or not.
 

--- a/ansible/roles/request-ocs/tasks/request-ocs.yml
+++ b/ansible/roles/request-ocs/tasks/request-ocs.yml
@@ -16,11 +16,11 @@
     mode: '0755'
 
 - name: Get ocp version minor
-  shell: bash -lc "oc version | grep Server | rev | cut -f1 -d' '| cut -f1 -d'.' --complement| rev | cut -f2 -d'.'"
+  shell: "oc version | grep Server | rev | cut -f1 -d' '| cut -f1 -d'.' --complement| rev | cut -f2 -d'.'"
   register: ocpversion
 
 - name: Get ocs version major.minor
-  shell: bash -lc "[[  {{ ocpversion.stdout }} -gt 5 ]] && echo 'stable-4.5' || echo 'stable-4.4'"
+  shell:  "if [  {{ ocpversion.stdout }} -gt 5 ]; then echo 'stable-4.5'; else echo 'stable-4.4'; fi"
   register: ocsversion
 
 - name: Install ocs from channel {{ ocsversion.stdout }}

--- a/ansible/roles/request-ocs/tasks/request-ocs.yml
+++ b/ansible/roles/request-ocs/tasks/request-ocs.yml
@@ -15,7 +15,7 @@
     dest: "{{ ocs_bastion_setup_dir }}/ocs_install.sh"
     mode: '0755'
 
-- name: Install ocs from channel {{ ocsversion.stdout }}
+- name: Install ocs from channel {{ ocs_channel }}
   shell: bash -lc "{{ ocs_bastion_setup_dir }}/ocs_install.sh {{ ocs_channel }} {{ setdefault }}"
   args:
       warn: false

--- a/ansible/roles/request-ocs/tasks/request-ocs.yml
+++ b/ansible/roles/request-ocs/tasks/request-ocs.yml
@@ -15,16 +15,8 @@
     dest: "{{ ocs_bastion_setup_dir }}/ocs_install.sh"
     mode: '0755'
 
-- name: Get ocp version minor
-  shell: "oc version | grep Server | rev | cut -f1 -d' '| cut -f1 -d'.' --complement| rev | cut -f2 -d'.'"
-  register: ocpversion
-
-- name: Get ocs version major.minor
-  shell:  "if [  {{ ocpversion.stdout }} -gt 5 ]; then echo 'stable-4.5'; else echo 'stable-4.4'; fi"
-  register: ocsversion
-
 - name: Install ocs from channel {{ ocsversion.stdout }}
-  shell: bash -lc "{{ ocs_bastion_setup_dir }}/ocs_install.sh {{ ocsversion.stdout }} {{ setdefault }}"
+  shell: bash -lc "{{ ocs_bastion_setup_dir }}/ocs_install.sh {{ ocsversion }} {{ setdefault }}"
   args:
       warn: false
   register: ocsinstall

--- a/ansible/roles/request-ocs/tasks/request-ocs.yml
+++ b/ansible/roles/request-ocs/tasks/request-ocs.yml
@@ -15,8 +15,16 @@
     dest: "{{ ocs_bastion_setup_dir }}/ocs_install.sh"
     mode: '0755'
 
-- name: Install ocs from channel {{ ocs_channel }}
-  shell: bash -lc "{{ ocs_bastion_setup_dir }}/ocs_install.sh {{ ocs_channel }} {{ setdefault }}"
+- name: Get ocp version minor
+  shell: bash -lc "oc version | grep Server | rev | cut -f1 -d' '| cut -f1 -d'.' --complement| rev | cut -f2 -d'.'"
+  register: ocpversion
+
+- name: Get ocs version major.minor
+  shell: bash -lc "[[  {{ ocpversion.stdout }} -gt 5 ]] && echo 'stable-4.5' || echo 'stable-4.4'"
+  register: ocsversion
+
+- name: Install ocs from channel {{ ocsversion.stdout }}
+  shell: bash -lc "{{ ocs_bastion_setup_dir }}/ocs_install.sh {{ ocsversion.stdout }} {{ setdefault }}"
   args:
       warn: false
   register: ocsinstall

--- a/ansible/roles/request-ocs/tasks/request-ocs.yml
+++ b/ansible/roles/request-ocs/tasks/request-ocs.yml
@@ -16,7 +16,7 @@
     mode: '0755'
 
 - name: Install ocs from channel {{ ocsversion.stdout }}
-  shell: bash -lc "{{ ocs_bastion_setup_dir }}/ocs_install.sh {{ ocsversion }} {{ setdefault }}"
+  shell: bash -lc "{{ ocs_bastion_setup_dir }}/ocs_install.sh {{ ocs_channel }} {{ setdefault }}"
   args:
       warn: false
   register: ocsinstall


### PR DESCRIPTION
1) Add support for ocs 4.5 when ocp 4.6 is installed.
2) Dynamically figure out what ocp version your using and the select the correct ocs version to install.