### PR TITLE
Enable install of rook-ceph v1.5 releases

### DIFF
--- a/ansible/roles/csi-cephfs-fyre/files/csi-ceph.sh
+++ b/ansible/roles/csi-cephfs-fyre/files/csi-ceph.sh
@@ -7,6 +7,16 @@ oc login -u kubeadmin -p "$(cat /root/auth/kubeadmin-password)" https://api.$(ho
 rm -rf rook
 echo "Doing clone of rook release $rookRelease"
 git clone https://github.com/rook/rook.git -b $rookRelease
+# if rook-ceph is version 1.5, then need to create/apply crd
+majorRelease=$(echo ${rookRelease:0:4})
+if [[ $majorRelease != "v1.4" ]]
+then
+  echo "Doing crds.yaml"
+  oc create -f rook/cluster/examples/kubernetes/ceph/crds.yaml
+  echo "crds.yaml exit $?"
+else
+  echo "No reason to apply crds.yaml as file may not exist"
+fi
 echo "Doing common.yaml"
 oc create -f rook/cluster/examples/kubernetes/ceph/common.yaml
 echo "common.yaml exit $?"


### PR DESCRIPTION
This PR aims to solve the issue in the link below
https://github.com/IBM/community-automation/issues/68

I have tested the code to work in Jenkins job and the job worked with rook-ceph v1.5.3 being installed without any issue. I have confirmed that the install of rook-ceph v1.4.8 also works with the below code. 