### PR TITLE
Ansible Playbook erroring, saying the worker_num cannot be zero

### DIFF
--- a/ansible/roles/request-ocp-roks/tasks/create-cluster.yml
+++ b/ansible/roles/request-ocp-roks/tasks/create-cluster.yml
@@ -15,6 +15,7 @@
     name: "{{ clusterName }}"
     datacenter: "{{ dataCenter }}"
     hardware: "{{ hardware }}"
+    worker_num: "{{ defaultPoolSize }}"
     default_pool_size: "{{ defaultPoolSize }}"
     kube_version: "{{ kubeVersion }}"
     private_vlan_id: "{{ privateVLAN }}"


### PR DESCRIPTION
Following work for the issue opened https://github.com/IBM/community-automation/issues/89, the PR that went it removed a neccessary line of code which provided a value for the `worker_num` required. Just added that line back in