### PR TITLE
Add site parm and readme update for ocp fyre cluster creates

### DIFF
--- a/ansible/request-ocp-fyre-play/README.md
+++ b/ansible/request-ocp-fyre-play/README.md
@@ -19,17 +19,21 @@
     - All QuickBurn clusters are created with an additional /dev/vdb 200G disk on the worker nodes.
 ## Custom installations additional information
 - Using the `custom` installation gives you a wide variety of installation options, so much so, that it can be very easy to not set correct values when using it. So to start we are going to give you some templates for installation that we think will be most useful and then follow with more detail for those that need something more.
+ - Ansible call to install the stable patch level of OCP 4.7.0-rc.2 nightly
+    - `ansible-playbook  -i inventory request-ocp-fyre-play.yml -e "clusterName=your47rc2clustername" -e "fyre_ocptype=ocpplus" -e "ocpVersion=custom" -e "rhcos_version_path=pre-release/latest" -e "ocp_version_path=ocp/4.7.0-rc.2"`
+ - Ansible call to install the stable patch level of OCP 4.7 nightly
+    - `ansible-playbook  -i inventory request-ocp-fyre-play.yml -e "clusterName=your47nightlyclustername" -e "fyre_ocptype=ocpplus" -e "ocpVersion=custom" -e "rhcos_version_path=pre-release/latest" -e "ocp_version_path=ocp-dev-preview/latest-4.7"`
   - Ansible call to install the stable patch level of OCP 4.6
-    - `ansible-playbook  -i inventory request-ocp-fyre-play.yml -e "clusterName=your45clustername" -e "fyre_ocptype=ocpplus" -e "ocpVersion=custom" -e "rhcos_version_path=4.6/latest" -e "ocp_version_path=ocp/stable-4.6"`
+    - `ansible-playbook  -i inventory request-ocp-fyre-play.yml -e "clusterName=your46clustername" -e "fyre_ocptype=ocpplus" -e "ocpVersion=custom" -e "rhcos_version_path=4.6/latest" -e "ocp_version_path=ocp/stable-4.6"`
   - Ansible call to install the stable patch level of OCP 4.5
-    - `ansible-playbook  -i inventory request-ocp-fyre-play.yml -e "clusterName=your44clustername" -e "fyre_ocptype=ocpplus" -e "ocpVersion=custom" -e "rhcos_version_path=4.5/latest" -e "ocp_version_path=ocp/stable-4.5"`
+    - `ansible-playbook  -i inventory request-ocp-fyre-play.yml -e "clusterName=your45clustername" -e "fyre_ocptype=ocpplus" -e "ocpVersion=custom" -e "rhcos_version_path=4.5/latest" -e "ocp_version_path=ocp/stable-4.5"`
 - So for installations that the previous ansible call templates do not satisfy here are some additional points to understand.
-  - The `custom` installation uses under the covers a fairly complicated API call that involves 5 URLs to get the information it needs to do a correct installation. Following are examples of the api_parm:URLs it uses for the latest nightly 4.6 installation.
+  - The `custom` installation uses under the covers a fairly complicated API call that involves 5 URLs to get the information it needs to do a correct installation. Following are examples of the api_parm:URLs it uses for the latest nightly 4.7 installation.
     - "kernel_url":"https://mirror.openshift.com/pub/openshift-v4/x86_64/dependencies/rhcos/pre-release/latest/rhcos-installer-kernel-x86_64"
     - "initramfs_url":"https://mirror.openshift.com/pub/openshift-v4/x86_64/dependencies/rhcos/pre-release/latest/rhcos-installer-initramfs.x86_64.img"
     - "metal_url":"https://mirror.openshift.com/pub/openshift-v4/x86_64/dependencies/rhcos/pre-release/latest/rhcos-metal.x86_64.raw.gz"
-    - "install_url":"https://mirror.openshift.com/pub/openshift-v4/x86_64/clients/ocp-dev-preview/latest-4.6/openshift-install-linux.tar.gz"
-    - "client_url":"https://mirror.openshift.com/pub/openshift-v4/x86_64/clients/ocp-dev-preview/latest-4.6/openshift-client-linux.tar.gz"
+    - "install_url":"https://mirror.openshift.com/pub/openshift-v4/x86_64/clients/ocp-dev-preview/latest-4.7/openshift-install-linux.tar.gz"
+    - "client_url":"https://mirror.openshift.com/pub/openshift-v4/x86_64/clients/ocp-dev-preview/latest-4.7/openshift-client-linux.tar.gz"
   - The additional parms for `custom` installations basically fill in sub directories of the URLs. Following are the additional parms:
     - `rhcos_version_path` - In the URLs above this parm would replace a section of the api parms  keranel_url, initramfs_url and metal_url URLs as follows:
       - "kernel_url":"https://mirror.openshift.com/pub/openshift-v4/x86_64/dependencies/rhcos/<rhcos_version_path>/rhcos-installer-kernel-x86_64"
@@ -39,8 +43,9 @@
       - "install_url":"https://mirror.openshift.com/pub/openshift-v4/x86_64/clients/<ocp_version_path>/openshift-install-linux.tar.gz"
       - "client_url":"https://mirror.openshift.com/pub/openshift-v4/x86_64/clients/<ocp_version_path>/openshift-client-linux.tar.gz"
   - Getting the right combination of `rhcos_version_path` and `ocp_version_path` can take some work. It is recommended to leave `rhcos_version_path` as one of the following versions and just do adjustments to the 'ocp_version_path'.
-    - For OCP 4.6 installations use `rhcos_version_path=4.5/latest`   
-    - For OCP 4.5 installations use `rhcos_version_path=4.4/latest`
+    - For OCP 4.7 nightly installations use `rhcos_version_path=pre-release/latest`   
+    - For OCP 4.6 installations use `rhcos_version_path=4.6/latest`   
+    - For OCP 4.5 installations use `rhcos_version_path=4.5/latest`
 
 ## Assumptions:
 

--- a/ansible/request-ocp-fyre-play/examples/ocp_vars_example.yml
+++ b/ansible/request-ocp-fyre-play/examples/ocp_vars_example.yml
@@ -1,5 +1,5 @@
 ocpPlatform: "x"
-
+fyre_site: "svl"
 fyre_master_quantity: 3
 fyre_master_cpu: 8
 fyre_master_memory: 16


### PR DESCRIPTION
Readme updates for ocp fyre on 4.7 and exposing the site parm in vars file.