### PR TITLE
switched to underscores for cephfs

### DIFF
--- a/ansible/roles/csi_cephfs_fyre/tasks/main.yml
+++ b/ansible/roles/csi_cephfs_fyre/tasks/main.yml
@@ -1,2 +1,2 @@
 ---
-- include_tasks: csi-cephfs-fyre.yaml
+- include_tasks: csi_cephfs_fyre.yaml


### PR DESCRIPTION
This is to fix the following error that I'm getting:

```
13:32:34 TASK [csi_cephfs_fyre] *********************************************************
13:32:34 
13:32:34 TASK [csi_cephfs_fyre : include_tasks] *****************************************
13:32:34 fatal: [9.30.209.114]: FAILED! => {"reason": "Could not find or access '/home/jenkins/workspace/Configure-OCPPlus-Cluster/ansible/csi-cephfs-fyre-play/csi-cephfs-fyre.yaml' on the Ansible Controller."}
```