### PR TITLE
update cr name

### DIFF
--- a/ansible/roles/ocp_pool_claim/tasks/ocp-pool-claim.yml
+++ b/ansible/roles/ocp_pool_claim/tasks/ocp-pool-claim.yml
@@ -14,14 +14,14 @@
       register: claim_results
 
     - name: check for claim readiness, wait up to 1 hour
-      shell: "./oc get clusterclaim {{ claim_name }}  -n {{ pool_namespace }} -o yaml"
+      shell: "./oc get clusterclaim.hive {{ claim_name }}  -n {{ pool_namespace }} -o yaml"
       register: ready_results
       until: 'ready_results.stdout.find("message: Cluster is running") != -1'
       retries: 60
       delay: 60
 
     - name: get claim namespace
-      shell: "./oc get clusterclaim {{ claim_name }} -n {{ pool_namespace }}  -o json | jq -r '.spec.namespace'"
+      shell: "./oc get clusterclaim.hive {{ claim_name }} -n {{ pool_namespace }}  -o json | jq -r '.spec.namespace'"
       register: ns_results
 
     - name: get kubeadmin password


### PR DESCRIPTION
ACM 2.2 broken cluster claiming with duplicate CR names.  For cluster claiming we need to add .hive to name.