### PR TITLE
common-service-play: db2u operator install alongside ics

### DIFF
--- a/ansible/common-service-play/examples/cs_vars.yml
+++ b/ansible/common-service-play/examples/cs_vars.yml
@@ -9,5 +9,6 @@ cs_subscription_channel: stable-v1 # this relates to catalog image above, exampl
 cs_subscription_strategy: Automatic
 cs_operand_list: [] # leave empty list by default enable all operands. support name and pattern. example for cpd ["licensing","metering","commonui","iam"]
 cs_operand_to_disable: ["elastic"] # support name and pattern to disable operands
+db2_operator_catalog_image: docker.io/ibmcom/ibm-operator-catalog
 storageclass_name: ""
 strict_validation: true

--- a/ansible/roles/common_services/README.md
+++ b/ansible/roles/common_services/README.md
@@ -19,9 +19,10 @@ Role Variables
 | cs_operator_project_name  | no       | common-service                                     | Namespace to use for installing Common Services operators |
 | cs_operator_catalog_image | no       | docker.io/ibmcom/ibm-common-service-catalog:latest | `latest` for stable and beta channels, `3.5-beta1` also valid |
 | cs_subscription_channel   | no       | stable-v1                                          | stable-v1, beta                                              |
-| cs_subscription_strategy  | no       | Automatic                                          | Approval stragergy for operator subscription              |
+| cs_subscription_strategy  | no       | Automatic                                          | Approval strategy for operator subscription              |
 | cs_operand_list           | no       | []                                                 | List of Operands to install, name or pattern. empty list default to everything |
 | cs_operand_to_disable     | no       | ["elastic"]                                        | List of Operands to disable, name or pattern              |
+| db2_operator_catalog_image | no      | docker.io/ibmcom/ibm-operator-catalog | `latest` for stable channel 
 | storageclass_name         | no       | managed-nfs-storage                                | StorageClass name                                         |
 | strict_validation         | no       | true                                               | Specify if to validate deployment strictly                |
 

--- a/ansible/roles/common_services/defaults/main.yml
+++ b/ansible/roles/common_services/defaults/main.yml
@@ -9,5 +9,6 @@ cs_subscription_channel: stable-v1 # this relates to catalog image above, exampl
 cs_subscription_strategy: Automatic
 cs_operand_list: [] # leave empty list by default enable all operands. support name and pattern. example for cpd ["licensing","metering","commonui","iam"]
 cs_operand_to_disable: ["elastic"] # support name and pattern to disable operands
+db2_operator_catalog_image: docker.io/ibmcom/ibm-operator-catalog
 storageclass_name: ""
 strict_validation: true

--- a/ansible/roles/common_services/tasks/install-db2.yml
+++ b/ansible/roles/common_services/tasks/install-db2.yml
@@ -1,0 +1,121 @@
+---
+# tasks file for ocp4 common services installation
+
+- name: Retrieve default StorageClass
+  shell: |
+    oc get storageclass | grep "(default)" | awk '{print $1}'
+  register: default_sc
+
+- name: Reset default StorageClass
+  when: default_sc.stdout|length|int > 0 and storageclass_name != ""
+  shell: |
+    oc patch storageclass {{ default_sc.stdout }} -p '{"metadata": {"annotations": {"storageclass.kubernetes.io/is-default-class": "false"}}}'
+
+- name: Making user specified StorageClass as default
+  when: storageclass_name != ""
+  shell: |
+    oc patch storageclass {{ storageclass_name }} -p '{"metadata": {"annotations": {"storageclass.kubernetes.io/is-default-class": "true"}}}'
+
+- name: Apply the CRDs
+  shell: |
+    oc apply -f catalog-source.yaml
+    oc apply -f db2-catalog-source.yaml
+    oc new-project {{ cs_operator_project_name }}
+    sleep 5
+    oc -n {{ cs_operator_project_name }} apply -f cs-group.yaml
+    oc -n {{ cs_operator_project_name }} apply -f cs-sub.yaml
+  args:
+    chdir: "{{ cs_setup_dir }}"
+
+# The Operand Deployment Lifecycle Manager is not always available immediately
+- name: Waiting for Operand Deployment Lifecycle Manager to complete
+  shell: "oc -n {{ cs_operator_project_name }} get csv --no-headers | grep operand-deployment-lifecycle-manager | grep Succeeded | wc -l"
+  register: operand_count
+  until: operand_count.stdout|int != 0
+  retries: 10
+  delay: 30
+
+- name: Making sure CRD OperandRegistry is present
+  shell: "oc -n ibm-common-services get operandregistry --no-headers | grep common-service | wc -l"
+  register: crdc_count
+  until: crdc_count.stdout|int == 1
+  retries: 10
+  delay: 30
+
+- name: Query available operands
+  shell: oc -n ibm-common-services get operandregistry common-service -o jsonpath='{.spec.operators[*].name}'
+  register: oc_operands
+
+- name: Display available operands
+  debug:
+    msg: "{{ oc_operands.stdout.split() }}"
+
+- name: Generate OperandRequest
+  shell: |
+    bash cs-request.bash; cat operandrequest.yml
+  register: deploy_operands
+  args:
+    chdir: "{{ cs_setup_dir }}"
+
+- name: Display generated OperandRequest
+  debug:
+    msg: "{{ deploy_operands.stdout_lines }}"
+
+- name: Deploy generated OperandRequest
+  shell: |
+    oc project ibm-common-services
+    oc -n ibm-common-services apply -f operandrequest.yml
+  args:
+    chdir: "{{ cs_setup_dir }}"
+
+- name: Waiting for ClusterServiceVersion to initialize
+  shell: |
+    sleep 30
+    oc -n ibm-common-services get csv --no-headers | grep -v operand-deployment-lifecycle-manager | wc -l
+  register: csvi_count
+  until: csvi_count.stdout|int >= 1
+  retries: 15
+  delay: 30
+
+- name: Waiting for all ClusterServiceVersion to complete
+  shell: "sleep 30; oc -n ibm-common-services get csv --no-headers | grep -v Succeeded | wc -l"
+  register: csvc_count
+  until: csvc_count.stdout|int == 0
+  retries: 45
+  delay: 30
+
+- name: Make sure Mongodb is present
+  shell: "sleep 30; oc -n ibm-common-services get statefulset --no-headers | grep -i mongodb | wc -l"
+  register: mongo_count
+  until: mongo_count.stdout|int != 0
+  retries: 5
+  delay: 30
+
+- name: Make sure all Statefulsets are healthy
+  shell: "sleep 30; oc -n ibm-common-services get statefulset --no-headers | egrep \"0/1|0/2|1/2|0/3|1/3|2/3\" | wc -l"
+  register: statefulset_unhealthy
+  until: statefulset_unhealthy.stdout|int == 0
+  retries: 30
+  delay: 30
+
+- name: Make sure all jobs are completed
+  shell: "sleep 30; oc -n ibm-common-services get job --no-headers | egrep \"0/1|0/2|1/2|0/3|1/3|2/3\" | wc -l"
+  register: job_notcompleted
+  until: job_notcompleted.stdout|int == 0
+  retries: 15
+  delay: 30
+
+- name: Validation with statefulsets and jobs
+  shell: "bash cs-validation.bash"
+  args:
+    chdir: "{{ cs_setup_dir }}"
+
+- name: Query console admin password
+  shell: |
+    oc -n ibm-common-services get route cp-console -o jsonpath='{.spec.host}'; echo
+    oc -n ibm-common-services get secret platform-auth-idp-credentials -o jsonpath='{.data.admin_password}' | base64 -d
+  register: cs_admin_password
+
+- name: Display console admin password
+  debug:
+    msg: "Console route is: {{ cs_admin_password.stdout_lines[0] }}    Console admin password is: {{ cs_admin_password.stdout_lines[1] }}"

--- a/ansible/roles/common_services/tasks/main.yml
+++ b/ansible/roles/common_services/tasks/main.yml
@@ -20,6 +20,7 @@
   - catalog-source.yaml
   - cs-request.bash
   - cs-validation.bash
+  - db2-catalog-source.yaml
 
 - name: Check for an oc connection
   shell: |

--- a/ansible/roles/common_services/tasks/main.yml
+++ b/ansible/roles/common_services/tasks/main.yml
@@ -42,3 +42,7 @@
 - include: "install.yml"
   static: no
   when: cs_action == "install"
+
+- include: "install-db2.yml"
+  static: no
+  when: cs_action == "install-db2"

--- a/ansible/roles/common_services/templates/db2-catalog-source.yaml.j2
+++ b/ansible/roles/common_services/templates/db2-catalog-source.yaml.j2
@@ -1,0 +1,13 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: CatalogSource
+metadata:
+  name: ibm-operator-catalog
+  namespace: openshift-marketplace
+spec:
+  displayName: ibm-operator-catalog
+  publisher: IBM Content
+  sourceType: grpc
+  image: {{ db2_operator_catalog_image }}
+  updateStrategy:
+    registryPoll:
+      interval: 45m


### PR DESCRIPTION
Provides user the option of installing db2u operator while installing common-services. This is a new feature that has been added with ICS 3.7.1. I tested this branch in my code and was able to successfully get CS 3.7.1 and db2u operator installed as you can see with the image below

![image](https://user-images.githubusercontent.com/8367234/112494595-91a44600-8d59-11eb-903e-eff55bb83d3e.png)

This PR is related to this open issue https://github.com/IBM/community-automation/issues/128