### PR TITLE
change default host_group for add_host

### DIFF
--- a/ansible/request-ocp-ceph-fyre-play/request-ocp-ceph.yml
+++ b/ansible/request-ocp-ceph-fyre-play/request-ocp-ceph.yml
@@ -5,7 +5,7 @@
   - role: request_ocp_fyre
 
 - name: Install csi-cephfs onto OCP+Beta Fyre cluster
-  hosts: ocp-clusters
+  hosts: ocpClusters
   gather_facts: false
   roles:
   - role: git_install_fyre

--- a/ansible/request-ocp-cs-install-fyre-play/request-ocp-cs-install.yml
+++ b/ansible/request-ocp-cs-install-fyre-play/request-ocp-cs-install.yml
@@ -5,7 +5,7 @@
   - role: request_ocp_fyre
 
 - name: Install csi-cephfs and then common services onto OCP+Beta Fyre cluster
-  hosts: ocp-clusters
+  hosts: ocpClusters
   gather_facts: false
   roles:
   - role: git_install_fyre

--- a/ansible/request-ocp-fyre-play/request-ocp-fyre-play.yml
+++ b/ansible/request-ocp-fyre-play/request-ocp-fyre-play.yml
@@ -3,7 +3,7 @@
   roles: 
   - role: request_ocp_fyre
 
-- hosts: ocp-clusters
+- hosts: ocpClusters
   gather_facts: false
   tasks:
   - name: Check machine alive

--- a/ansible/roles/request_ocp_fyre/defaults/main.yml
+++ b/ansible/roles/request_ocp_fyre/defaults/main.yml
@@ -5,7 +5,7 @@ fyreocpplus_clusterstatusurl: "{{ fyreocpplus_apiurl }}/v1/ocp/{{ clusterName }}
 fyre_ocpdeployurl: "{{ fyre_apiurl }}?operation=deployopenshiftcluster"
 fyreocpplus_ocpdeployurl: "{{ fyreocpplus_apiurl }}/v1/ocp/"
 fyre_opshowclusterurl: "{{ fyre_apiurl }}?operation=query&request=showclusters"
-fyre_ocp_inf_group: "ocp-clusters"
+fyre_ocp_inf_group: "ocpClusters"
 fyre_inf_node_name: "{{ clusterName | lower }}-inf"
 fyre_site: "svl"
 fyre_ocptype: "ocp"

--- a/ansible/roles/request_ocp_fyre/readme.md
+++ b/ansible/roles/request_ocp_fyre/readme.md
@@ -14,7 +14,7 @@ Will it is expected to run on a host with the following hostvars set in inventor
 The role expects to be supplied:
  - clusterName
  - ocpVersion
- - fyre_ocp_inf_group (optional: defaults to 'ocp-clusters')
+ - fyre_ocp_inf_group (optional: defaults to 'ocpClusters')
  - fyre_site (optional: defaults to svl)
 
 


### PR DESCRIPTION
fyre_ocp_inf_group is set in defaults/main.yml

The value of ocp-clusters is not valid do to -

I see the playbook had this defined as well.  I am wondering if it should become a param for the playbook too.  So it could be passed in and be used in both places, playbook and role.

