### PR TITLE
Added ability to authenticate to Docker registry

### DIFF
--- a/ansible/csi-cephfs-fyre-play/README.md
+++ b/ansible/csi-cephfs-fyre-play/README.md
@@ -54,6 +54,26 @@ or set new default storageclass to something other than csi-cephfs
 ```
 ansible-playbook  -i inventory csi-cephfs.yml --extra-vars "default_sc=rook-cephfs"
 ```
+
+or pass Docker registry authentication. Note that the `registry` variable must be specified in order for the playbook to setup the 
+ImagePullSecret.
+```
+ansible-playbook  -i inventory csi-cephfs.yml --extra-vars "registry=docker.io registry_user=MYUSER registry_pwd=MYPASSWORD"
+```
+Additionally if you have special characters in your variables (as is common with passwords) consider using a JSON or YAML file and 
+referencing it as below
+```
+ansible-playbook  -i inventory csi-cephfs.yml --extra-vars "@registry.json"
+```
+`registry.json`:
+```
+{
+  "registry": "docker.io",
+  "registry_user": "MYUSER",
+  "registry_pwd": "MYPASSWORD"
+}
+```
+
 License
 -------
 

--- a/ansible/roles/csi_cephfs_fyre/defaults/main.yml
+++ b/ansible/roles/csi_cephfs_fyre/defaults/main.yml
@@ -3,3 +3,6 @@ cephfs_bastion_setup_dir: ~/setup-files/ceph-setup
 rook_cephfs_release: v1.5.9  #Rook-ceph release from https://github.com/rook/rook/releases
 device_name: vdb
 default_sc: csi-cephfs
+registry: 
+registry_user: 
+registry_pwd: 

--- a/ansible/roles/csi_cephfs_fyre/files/csi-ceph.sh
+++ b/ansible/roles/csi_cephfs_fyre/files/csi-ceph.sh
@@ -3,8 +3,8 @@ rookRelease=$1
 device=$2
 new_default_sc=$3
 registry=$4
-registry_user=$4
-registry_pwd=$5
+registry_user=$5
+registry_pwd=$6
 
 oc login -u kubeadmin -p "$(cat /root/auth/kubeadmin-password)" https://api.$(hostname | cut -f1 -d'.' | rev | cut -f1 -d'-' --complement | rev).cp.fyre.ibm.com:6443 --insecure-skip-tls-verify=true
 

--- a/ansible/roles/csi_cephfs_fyre/files/csi-ceph.sh
+++ b/ansible/roles/csi_cephfs_fyre/files/csi-ceph.sh
@@ -44,6 +44,7 @@ else
   oc patch serviceaccount rook-ceph-system -p '{"imagePullSecrets": [{"name": "dockerhub-secret"}]}'
   oc patch serviceaccount rook-ceph-mgr -p '{"imagePullSecrets": [{"name": "dockerhub-secret"}]}'
   oc patch serviceaccount rook-ceph-osd -p '{"imagePullSecrets": [{"name": "dockerhub-secret"}]}'
+  oc patch serviceaccount rook-ceph-cmd-reporter -p '{"imagePullSecrets": [{"name": "dockerhub-secret"}]}'
 fi
 echo "setup Docker registry image pull secrets exit"
 

--- a/ansible/roles/csi_cephfs_fyre/tasks/csi_cephfs_fyre.yaml
+++ b/ansible/roles/csi_cephfs_fyre/tasks/csi_cephfs_fyre.yaml
@@ -22,7 +22,7 @@
     mode: '0755'
 
 - name: Install csi-cephfs
-  shell: "{{ cephfs_bastion_setup_dir }}/csi-ceph.sh {{ rook_cephfs_release }}  {{ device_name }} {{ default_sc }}"
+  shell: "{{ cephfs_bastion_setup_dir }}/csi-ceph.sh {{ rook_cephfs_release }} {{ device_name }} {{ default_sc }} {{ registry }} {{ registry_user }} {{ registry_pwd }}"
   args:
       warn: false
   register: cephinstall

--- a/ansible/roles/csi_cephfs_fyre/tasks/csi_cephfs_fyre.yaml
+++ b/ansible/roles/csi_cephfs_fyre/tasks/csi_cephfs_fyre.yaml
@@ -22,7 +22,7 @@
     mode: '0755'
 
 - name: Install csi-cephfs
-  shell: "{{ cephfs_bastion_setup_dir }}/csi-ceph.sh {{ rook_cephfs_release }} {{ device_name }} {{ default_sc }} {{ registry }} {{ registry_user }} {{ registry_pwd }}"
+  shell: "{{ cephfs_bastion_setup_dir }}/csi-ceph.sh {{ rook_cephfs_release }} {{ device_name }} {{ default_sc }} {{ registry }} {{ registry_user }} '{{ registry_pwd }}'"
   args:
       warn: false
   register: cephinstall


### PR DESCRIPTION
Fix for issue #139. Added code to patch ServiceAccounts with an ImagePullSecret as documented here https://github.com/rook/rook/blob/master/Documentation/k8s-pre-reqs.md#authenticated-docker-registries. Tested on OCP QuickBurn environments both without specifying registry credentials and with specifying my own DockerHub registry credentials. 