### PR TITLE
oc client install needs to support older ansible

### DIFF
--- a/ansible/roles/oc_client_install/tasks/oc-client-install.yml
+++ b/ansible/roles/oc_client_install/tasks/oc-client-install.yml
@@ -28,7 +28,7 @@
       warn: false
 
   - name: Copy oc command to local bin
-    ansible.builtin.copy:
+    copy:
       src: oc
       dest: /usr/local/bin/oc
       owner: root
@@ -38,7 +38,7 @@
     become_user: root
 
   - name: Copy kubectl to local bin
-    ansible.builtin.copy:
+    copy:
       src: kubectl
       dest: /usr/local/bin/kubectl
       owner: root


### PR DESCRIPTION
Swapping ansible.builtin.copy to copy so that older versions of ansible can still like this role.