### PR TITLE
Fix the fyre role to support new style inf node naming

### DIFF
--- a/ansible/roles/request_ocp_fyre/defaults/main.yml
+++ b/ansible/roles/request_ocp_fyre/defaults/main.yml
@@ -6,7 +6,7 @@ fyre_ocpdeployurl: "{{ fyre_apiurl }}?operation=deployopenshiftcluster"
 fyreocpplus_ocpdeployurl: "{{ fyreocpplus_apiurl }}/v1/ocp/"
 fyre_opshowclusterurl: "{{ fyre_apiurl }}?operation=query&request=showclusters"
 fyre_ocp_inf_group: "ocpClusters"
-fyre_inf_node_name: "{{ clusterName | lower }}-inf"
+fyre_inf_node_name: "{{ clusterName | lower }}-inf" # Only used on old OCP (not OCP+)
 fyre_site: "svl"
 fyre_group_id: "0"
 fyre_ocptype: "ocp"

--- a/ansible/roles/request_ocp_fyre/tasks/request-ocpplus-fyre.yml
+++ b/ansible/roles/request_ocp_fyre/tasks/request-ocpplus-fyre.yml
@@ -77,8 +77,8 @@
 
 - name: Derive Info from Fyre Api
   set_fact:
-    fyre_inf_public_ip: "{{ cluster_status_response.json.clusters[0].vms | selectattr('ip_address') | selectattr('ip_address', 'match', '^9..*$' ) | map(attribute='ip_address') | list | first }}"
-    fyre_inf_hostname: "{{ cluster_status_response.json.clusters[0].vms | selectattr('ip_address') | selectattr('ip_address', 'match', '^9..*$' ) | map(attribute='hostname') | list | first }}"
+    fyre_inf_public_ip: "{{ cluster_status_response.json.clusters[0].vms | selectattr('ip_address','defined') | selectattr('ip_address', 'match', '^9..*$' ) | map(attribute='ip_address') | list | first }}"
+    fyre_inf_hostname: "{{ cluster_status_response.json.clusters[0].vms | selectattr('ip_address','defined') | selectattr('ip_address', 'match', '^9..*$' ) | map(attribute='hostname') | list | first }}"
 
 - name: remove new host from localhost known_hosts ip
   command: "ssh-keygen -R {{ fyre_inf_public_ip }}"

--- a/ansible/roles/request_ocp_fyre/tasks/request-ocpplus-fyre.yml
+++ b/ansible/roles/request_ocp_fyre/tasks/request-ocpplus-fyre.yml
@@ -77,8 +77,8 @@
 
 - name: Derive Info from Fyre Api
   set_fact:
-    fyre_inf_public_ip: "{{ cluster_status_response.json.clusters[0].vms | selectattr('ip_address', 'match', '^9..*$' ) | map(attribute='ip_address') | list | first }}"
-    fyre_inf_hostname: "{{ cluster_status_response.json.clusters[0].vms | selectattr('ip_address', 'match', '^9..*$' ) | map(attribute='hostname') | list | first }}"
+    fyre_inf_public_ip: "{{ cluster_status_response.json.clusters[0].vms | selectattr('ip_address') | selectattr('ip_address', 'match', '^9..*$' ) | map(attribute='ip_address') | list | first }}"
+    fyre_inf_hostname: "{{ cluster_status_response.json.clusters[0].vms | selectattr('ip_address') | selectattr('ip_address', 'match', '^9..*$' ) | map(attribute='hostname') | list | first }}"
 
 - name: remove new host from localhost known_hosts ip
   command: "ssh-keygen -R {{ fyre_inf_public_ip }}"

--- a/ansible/roles/request_ocp_fyre/tasks/request-ocpplus-fyre.yml
+++ b/ansible/roles/request_ocp_fyre/tasks/request-ocpplus-fyre.yml
@@ -77,7 +77,8 @@
 
 - name: Derive Info from Fyre Api
   set_fact:
-    fyre_inf_public_ip: "{{ cluster_status_response.json.clusters[0].vms | selectattr('hostname', 'equalto', fyre_inf_node_name) | map(attribute='ip_address') | list | first }}"
+    fyre_inf_public_ip: "{{ cluster_status_response.json.clusters[0].vms | selectattr('ip_address', 'match', '^9..*$' ) | map(attribute='ip_address') | list | first }}"
+    fyre_inf_hostname: "{{ cluster_status_response.json.clusters[0].vms | selectattr('ip_address', 'match', '^9..*$' ) | map(attribute='hostname') | list | first }}"
 
 - name: remove new host from localhost known_hosts ip
   command: "ssh-keygen -R {{ fyre_inf_public_ip }}"
@@ -85,14 +86,8 @@
   # changed_when: false Technically not true but change is not particularly meaningful
   failed_when: false
   delegate_to: localhost
-- name: remove new host from localhost known_hosts
-  command: "ssh-keygen -R {{ fyre_inf_node_name }}"
-  changed_when: false
-  # changed_when: false Technically not true but change is not particularly meaningful
-  failed_when: false
-  delegate_to: localhost
 - name: remove new host from localhost known_hosts fqdn
-  command: "ssh-keygen -R {{ fyre_inf_node_name }}.fyre.ibm.com"
+  command: "ssh-keygen -R {{ fyre_inf_hostname }}"
   changed_when: false
   # changed_when: false Technically not true but change is not particularly meaningful
   failed_when: false

--- a/ansible/roles/request_ocp_fyre/tasks/request-quickburn-fyre.yml
+++ b/ansible/roles/request_ocp_fyre/tasks/request-quickburn-fyre.yml
@@ -73,8 +73,8 @@
 
 - name: Derive Info from Fyre Api
   set_fact:
-    fyre_inf_public_ip: "{{ cluster_status_response.json.clusters[0].vms | selectattr('ip_address', 'match', '^9..*$' ) | map(attribute='ip_address') | list | first }}"
-    fyre_inf_hostname: "{{ cluster_status_response.json.clusters[0].vms | selectattr('ip_address', 'match', '^9..*$' ) | map(attribute='hostname') | list | first }}"
+    fyre_inf_public_ip: "{{ cluster_status_response.json.clusters[0].vms | selectattr('ip_address') | selectattr('ip_address', 'match', '^9..*$' ) | map(attribute='ip_address') | list | first }}"
+    fyre_inf_hostname: "{{ cluster_status_response.json.clusters[0].vms | selectattr('ip_address') | selectattr('ip_address', 'match', '^9..*$' ) | map(attribute='hostname') | list | first }}"
 
 - name: remove new host from localhost known_hosts ip
   command: "ssh-keygen -R {{ fyre_inf_public_ip }}"

--- a/ansible/roles/request_ocp_fyre/tasks/request-quickburn-fyre.yml
+++ b/ansible/roles/request_ocp_fyre/tasks/request-quickburn-fyre.yml
@@ -73,8 +73,8 @@
 
 - name: Derive Info from Fyre Api
   set_fact:
-    fyre_inf_public_ip: "{{ cluster_status_response.json.clusters[0].vms | selectattr('ip_address') | selectattr('ip_address', 'match', '^9..*$' ) | map(attribute='ip_address') | list | first }}"
-    fyre_inf_hostname: "{{ cluster_status_response.json.clusters[0].vms | selectattr('ip_address') | selectattr('ip_address', 'match', '^9..*$' ) | map(attribute='hostname') | list | first }}"
+    fyre_inf_public_ip: "{{ cluster_status_response.json.clusters[0].vms | selectattr('ip_address','defined') | selectattr('ip_address', 'match', '^9..*$' ) | map(attribute='ip_address') | list | first }}"
+    fyre_inf_hostname: "{{ cluster_status_response.json.clusters[0].vms | selectattr('ip_address','defined') | selectattr('ip_address', 'match', '^9..*$' ) | map(attribute='hostname') | list | first }}"
 
 - name: remove new host from localhost known_hosts ip
   command: "ssh-keygen -R {{ fyre_inf_public_ip }}"

--- a/ansible/roles/request_ocp_fyre/tasks/request-quickburn-fyre.yml
+++ b/ansible/roles/request_ocp_fyre/tasks/request-quickburn-fyre.yml
@@ -73,7 +73,8 @@
 
 - name: Derive Info from Fyre Api
   set_fact:
-    fyre_inf_public_ip: "{{ cluster_status_response.json.clusters[0].vms | selectattr('hostname', 'equalto', fyre_inf_node_name) | map(attribute='ip_address') | list | first }}"
+    fyre_inf_public_ip: "{{ cluster_status_response.json.clusters[0].vms | selectattr('ip_address', 'match', '^9..*$' ) | map(attribute='ip_address') | list | first }}"
+    fyre_inf_hostname: "{{ cluster_status_response.json.clusters[0].vms | selectattr('ip_address', 'match', '^9..*$' ) | map(attribute='hostname') | list | first }}"
 
 - name: remove new host from localhost known_hosts ip
   command: "ssh-keygen -R {{ fyre_inf_public_ip }}"
@@ -81,19 +82,13 @@
   # changed_when: false Technically not true but change is not particularly meaningful
   failed_when: false
   delegate_to: localhost
-- name: remove new host from localhost known_hosts
-  command: "ssh-keygen -R {{ fyre_inf_node_name }}"
-  changed_when: false
-  # changed_when: false Technically not true but change is not particularly meaningful
-  failed_when: false
-  delegate_to: localhost
 - name: remove new host from localhost known_hosts fqdn
-  command: "ssh-keygen -R {{ fyre_inf_node_name }}.fyre.ibm.com"
+  command: "ssh-keygen -R {{ fyre_inf_hostname }}"
   changed_when: false
   # changed_when: false Technically not true but change is not particularly meaningful
   failed_when: false
   delegate_to: localhost
-
+  
 - name: Add inf host to group
   add_host:
     name: "{{fyre_inf_public_ip}}"


### PR DESCRIPTION
Fyre changed how the infrastructure node within an OCP+ cluster worked. It new name was a fully qualified version of the api machine e.g. api.testinf2.cp.fyre.ibm.com

I have test this on the old style and on the new style.

Note roles like OCP_Login need a seperate fix but that should be covered by #165 