### PR TITLE
add error checking to provision_ocp_cluster

### DIFF
--- a/ansible/roles/provision_ocp_cluster/tasks/provision-cluster.yml
+++ b/ansible/roles/provision_ocp_cluster/tasks/provision-cluster.yml
@@ -100,16 +100,18 @@
     - name: Check for bootstrap complete, wait up to 60 minutes
       shell: "oc logs -n {{ CLUSTER_NAME }} {{ provision_podname }} -c hive"
       register: bootstrap_results
-      until: 'bootstrap_results.stdout.find("Bootstrap status: complete") != -1'
+      until: '(bootstrap_results.stdout.find("Bootstrap status: complete") != -1) or (bootstrap_results.stdout.find("error") == 0)'
       retries: 60
       delay: 60
+      failed_when: '(bootstrap_results.stdout.find("error") == 0)'
 
     - name: Check provisioning progress, waiting up to 60 minutes
       shell: "oc logs -n {{ CLUSTER_NAME }} {{ provision_podname }} -c hive"
       register: monitor_results
-      until: '(monitor_results.stdout.find("install completed successfully") != -1)'
+      until: '(monitor_results.stdout.find("install completed successfully") != -1) or (monitor_results.stdout.find("error") == 0)'
       retries: 60
       delay: 60
+      failed_when: '(monitor_results.stdout.find("error") == 0)'
 
     - name: Change to cluster namespace
       shell: "oc project {{ CLUSTER_NAME }}"


### PR DESCRIPTION
provision_ocp_cluster use RedHat Hive to deploy OCP clusters.  There was no error checking which as causing the playbook to run on without ending on errors.

