### PR TITLE
remove error checking

### DIFF
--- a/ansible/roles/hive_ocp_cluster_provision/tasks/provision-cluster.yml
+++ b/ansible/roles/hive_ocp_cluster_provision/tasks/provision-cluster.yml
@@ -96,18 +96,16 @@
 - name: Check for bootstrap complete, wait up to 60 minutes
   shell: "oc logs -n {{ CLUSTER_NAME }} {{ provision_podname }} -c hive"
   register: bootstrap_results
-  until: '(bootstrap_results.stdout.find("Bootstrap status: complete") != -1) or (bootstrap_results.stdout.find("error") > 0)'
+  until: '(bootstrap_results.stdout.find("Bootstrap status: complete") != -1)'
   retries: 60
   delay: 60
-  failed_when: '(bootstrap_results.stdout.find("error") > 0)'
 
 - name: Check provisioning progress, waiting up to 60 minutes
   shell: "oc logs -n {{ CLUSTER_NAME }} {{ provision_podname }} -c hive"
   register: monitor_results
-  until: '(monitor_results.stdout.find("install completed successfully") != -1) or (monitor_results.stdout.find("error") > 0)'
+  until: '(monitor_results.stdout.find("install completed successfully") != -1)'
   retries: 60
   delay: 60
-  failed_when: '(monitor_results.stdout.find("error") > 0)'
 
 - name: Change to cluster namespace
   shell: "oc project {{ CLUSTER_NAME }}"


### PR DESCRIPTION
Turns out "error" is in many places as part of help text.  So we cannot check for "error" string alone.  This is going to take some investigation.  I am removing the error check all together for now.