### PR TITLE
Ensure Secret get regen if they break first time

### DIFF
--- a/ansible/roles/instana_instance_on_prem/tasks/main.yml
+++ b/ansible/roles/instana_instance_on_prem/tasks/main.yml
@@ -162,7 +162,7 @@
 #END BLOCK
 
 - name: instana admin credentials
-  shell: 'cat instanaCreds 2>/dev/null || (instana configure admin >instanaCreds; cat instanaCreds)'
+  shell: '(grep "E-Mail" instanaCreds >/dev/null 2>&1 || (instana configure admin >instanaCreds)); cat instanaCreds'
   register: instanaAdmin
   changed_when: false
 


### PR DESCRIPTION
Had an issue were instana creds contained: "persistence settings could not be loaded: no settings found: /root/.instana/effective-settings.hcl"

The instanacreds would never regenerate so it couldnt fix itself