### PR TITLE
Fix OCP 4.8 for fyre OCS play

### DIFF
--- a/ansible/roles/request_ocs_local_storage/tasks/request_ocs_local_storage.yml
+++ b/ansible/roles/request_ocs_local_storage/tasks/request_ocs_local_storage.yml
@@ -34,6 +34,10 @@
   when: oc_version.stdout is version('4.7', '>=')
 
 - set_fact:
+    localstore_version: "4.8"
+  when: oc_version.stdout is version('4.8', '>=')
+
+- set_fact:
     local_storage_namespace: openshift-local-storage
   when: oc_version.stdout is version('4.6', '>=')
 
@@ -48,6 +52,10 @@
 - set_fact:
     ocs_channel: "stable-4.7"
   when: oc_version.stdout is version('4.7', '>=')
+
+- set_fact:
+    ocs_channel: "stable"
+  when: oc_version.stdout is version('4.8', '>=')
 
 - name: Generate OCS install files from templates and copy to dest
   template:


### PR DESCRIPTION
Attempted to install OCS on OCP 4.8, it failed.
This workaround worked.