### PR TITLE
changing node check and reduce timeout

### DIFF
--- a/ansible/roles/csi_cephfs_fyre/files/csi-ceph.sh
+++ b/ansible/roles/csi_cephfs_fyre/files/csi-ceph.sh
@@ -83,10 +83,10 @@ echo "Exit from cluster.yaml $?"
 
 num_worker_nodes=$(oc get no | tr -s ' ' | cut -f3 -d' ' | grep worker  | wc -l)
 echo "Check for the number of ceph nodes running is equal to numbers of worker nodes - wait up to 2 hour"
-ceph_sleep_count=120
+ceph_sleep_count=60
 while [[ $ceph_sleep_count -ne 0 ]]; do
   num_ceph_nodes=$(oc get po -n rook-ceph | grep rook-ceph-osd | grep -v prepare | grep -e Running | wc -l)
-  if [[ $num_worker_nodes -ne $num_ceph_nodes ]] ; then
+  if [[ $num_ceph_nodes -ge $num_worker_nodes ]] ; then
     echo "Waiting for ceph nodes to come active"
     sleep 1m
     ((ceph_sleep_count--))


### PR DESCRIPTION
this will resolve the problem with having 2 extra drives that come with cluster built using the UI OCP+ or quickburn.