### PR TITLE
Reduce retries when things go wrong

### DIFF
--- a/ansible/roles/fyrevm_delete/defaults/main.yml
+++ b/ansible/roles/fyrevm_delete/defaults/main.yml
@@ -1,1 +1,4 @@
 stackName: "{{ clusterName|default(omit) }}"
+
+fyre_modifyKnownHosts: true
+fyre_requestRetries: 999

--- a/ansible/roles/fyrevm_delete/tasks/fyrevm_delete.yml
+++ b/ansible/roles/fyrevm_delete/tasks/fyrevm_delete.yml
@@ -27,7 +27,7 @@
   - name: get Fyre request status
     no_log: "{{ noLog }}"
     command: 'curl -X POST -k -u {{ fyreuser }}:{{ fyreapikey }} {{ fyrerequeststatus }}{{ (deleteStatus.stdout|from_json).request_id }}'
-    retries: {{ fyre_requestRetries }}
+    retries: "{{ fyre_requestRetries }}"
     delay: 5
     args:
      warn: no

--- a/ansible/roles/fyrevm_delete/tasks/fyrevm_delete.yml
+++ b/ansible/roles/fyrevm_delete/tasks/fyrevm_delete.yml
@@ -27,7 +27,7 @@
   - name: get Fyre request status
     no_log: "{{ noLog }}"
     command: 'curl -X POST -k -u {{ fyreuser }}:{{ fyreapikey }} {{ fyrerequeststatus }}{{ (deleteStatus.stdout|from_json).request_id }}'
-    retries: 999
+    retries: {{ fyre_requestRetries }}
     delay: 5
     args:
      warn: no
@@ -50,6 +50,7 @@
     command: "ssh-keygen -R {{ stackName }}-1.fyre.ibm.com" 
     ignore_errors: True
     delegate_to: localhost
+    when: "fyre_modifyKnownHosts|bool == true"
   
   - name: remove temp json
     file:
@@ -58,4 +59,3 @@
     delegate_to: localhost
 
   when: deleteStatus.stdout is not search('error')
-

--- a/ansible/roles/fyrevm_provision/defaults/main.yml
+++ b/ansible/roles/fyrevm_provision/defaults/main.yml
@@ -1,11 +1,16 @@
 ### helpful for debug to set noLog to false via -e noLog=false
 noLog: False
 
-
 fyre_addAnsibleHost: true
+fyre_modifyKnownHosts: true
 fyre_emberSuffix: "1"
 clusterName: "{{ stackName|default(clusterName_prefix+'-'+ (999999|random)|string) }}"
 ssh_public_key: "{{ lookup('file', lookup('env','HOME') + '/.ssh/id_rsa.pub') }}"
+
+# How many times to retry waiting for an ssh connection after provisioning
+fyre_sshRetries: 250
+# How many times to wait for a fyre request to complete
+fyre_requestRetries: 999
 
 #Default Specs
 fyre_platform: "x"

--- a/ansible/roles/fyrevm_provision/tasks/fyrevm_provision.yml
+++ b/ansible/roles/fyrevm_provision/tasks/fyrevm_provision.yml
@@ -10,7 +10,8 @@
   file:
     path: "{{ lookup('env','HOME')}}/.ssh/known_hosts"
     state: touch
-    mode: '0600'     
+    mode: '0600'
+  when: "fyre_modifyKnownHosts|bool == true"
 - name: Ensure SSH Key
   openssh_keypair:
     path: "{{ lookup('env','HOME')}}/.ssh/id_rsa"
@@ -62,7 +63,7 @@
       return_content: yes
       body_format: json
     no_log: "{{ noLog }}"
-    retries: 999
+    retries: "{{ fyre_requestRetries }}"
     delay: 5
     register: fyreStatus
     until: fyreStatus.json.request[0].get('status') == 'error' or fyreStatus.json.request[0].get('status') == 'completed'
@@ -103,19 +104,22 @@
     publicip: "{{ clusterStatus.json[clusterName][0].publicip }}"
   command: "ssh-keygen -R {{ publicip }}"
   ignore_errors: True
+  when: "fyre_modifyKnownHosts|bool == true"
 - name: remove new host from localhost known_hosts
   no_log: "{{ noLog }}"
   command: "ssh-keygen -R {{ ember }}"
   ignore_errors: True
+  when: "fyre_modifyKnownHosts|bool == true"
 - name: remove new host from localhost known_hosts fqdn
   no_log: "{{ noLog }}"
   command: "ssh-keygen -R {{ emberFQDN }}" 
   ignore_errors: True
+  when: "fyre_modifyKnownHosts|bool == true"
 
 # somewhat hard coded here
 - name: check the host for a active ssh
   command: 'ssh -o PasswordAuthentication=no -o StrictHostKeyChecking=no root@{{ emberFQDN }} /usr/bin/true'
-  retries: 999
+  retries: "{{ fyre_sshRetries }}"
   delay: 5
   register: result
   until: result.rc == 0
@@ -123,6 +127,7 @@
 # somewhat hard coded here
 - name: add host to known_hosts
   shell: 'ssh-keyscan -H {{ emberFQDN }} >> ~/.ssh/known_hosts'
+  when: "fyre_modifyKnownHosts|bool == true"
 
 - add_host:
    name: "{{ emberFQDN }}"

--- a/ansible/roles/fyrevm_provision/tasks/fyrevm_provision.yml
+++ b/ansible/roles/fyrevm_provision/tasks/fyrevm_provision.yml
@@ -116,7 +116,6 @@
   ignore_errors: True
   when: "fyre_modifyKnownHosts|bool == true"
 
-# somewhat hard coded here
 - name: check the host for a active ssh
   command: 'ssh -o PasswordAuthentication=no -o StrictHostKeyChecking=no root@{{ emberFQDN }} /usr/bin/true'
   retries: "{{ fyre_sshRetries }}"

--- a/ansible/roles/fyrevm_provision/tasks/fyrevm_provision.yml
+++ b/ansible/roles/fyrevm_provision/tasks/fyrevm_provision.yml
@@ -70,7 +70,7 @@
 
   - name: check Fyre request status
     fail:
-      msg: "Fyre reqeust for cluster {{ clusterName }} has failed\n(fyreStatus.json.request[0].get('error_details')"
+      msg: "Fyre reqeust for cluster {{ clusterName }} has failed:\n{{ fyreStatus.json.request[0].get('error_details') | default('No reason given')}}"
     when: fyreStatus.json.request[0].get('status') == 'error'
   #END BLOCK
 


### PR DESCRIPTION
The current 999 retries can lead to provision failures taking 33 hours, if the ssh connection fails with a timeout (2 mins) 999 times.