### PR TITLE
Update csi_cephfs_vmware.yaml to remove use of arg warn

### DIFF
--- a/ansible/roles/csi_cephfs_vmware/tasks/csi_cephfs_vmware.yaml
+++ b/ansible/roles/csi_cephfs_vmware/tasks/csi_cephfs_vmware.yaml
@@ -23,8 +23,6 @@
   shell: "rm -rf rook; csi-ceph.sh {{ rook_cephfs_release }}  {{ device_name }} {{ default_sc }}"
   environment:
      KUBECONFIG: "{{ kubeconfig_location }}/config"
-  args:
-      warn: false
   register: cephinstall
 
 - name: Viewing csi-cephfs install log
@@ -35,8 +33,6 @@
   shell: "wait-for-csi-ceph.sh"
   environment:
      KUBECONFIG: "{{ kubeconfig_location }}/config"
-  args:
-      warn: false
   register: waitceph
 
 - name: Viewing Waiting for rook-ceph-mds-myfs pods to go to Running Log


### PR DESCRIPTION
`warn` has been deprecated in ansible-core 2.14. For this task to work with later versions we need to remove this.

Fix tested using ansible 2.13 (6.7.0) and 2.14 (7.4.0).

This was the error:
`Unsupported parameters for (ansible.legacy.command) module: warn. Supported parameters include: _raw_params, _uses_shell, argv, chdir, creates, executable, removes, stdin, stdin_add_newline, strip_empty_ends`