### PR TITLE
Stop sending json=null to fyre

### DIFF
--- a/ansible/roles/fyrevm_provision/tasks/fyrevm_provision.yml
+++ b/ansible/roles/fyrevm_provision/tasks/fyrevm_provision.yml
@@ -58,13 +58,12 @@
   - name: get Fyre request status
     uri:
       url: "{{ fyre_requeststatusurl }}{{ (buildstatus.json).request_id }}"
-      method: "POST"
+      method: "GET"
       user: "{{ fyreuser }}"
       password: "{{ fyreapikey }}"
       force_basic_auth: True
       validate_certs: False
       return_content: yes
-      body_format: json
     no_log: "{{ noLog }}"
     retries: "{{ fyre_requestRetries }}"
     delay: 5


### PR DESCRIPTION
Where we request status from fyre, it should be a get not a POST and we are not sending any body, so we should avoid setting body_format. Setting body_format causes ansible to send json=null.

Fyre is looking to turn on "ModSecurity: Cannot add scalar value without an associated key" which would block such requests. We need to fix our code before fyre breaks us.