### PR TITLE
Fyre json issue

### DIFF
--- a/ansible/roles/fyrevm_provision/tasks/fyrevm_provision.yml
+++ b/ansible/roles/fyrevm_provision/tasks/fyrevm_provision.yml
@@ -58,13 +58,12 @@
   - name: get Fyre request status
     uri:
       url: "{{ fyre_requeststatusurl }}{{ (buildstatus.json).request_id }}"
-      method: "POST"
+      method: "GET"
       user: "{{ fyreuser }}"
       password: "{{ fyreapikey }}"
       force_basic_auth: True
       validate_certs: False
       return_content: yes
-      body_format: json
     no_log: "{{ noLog }}"
     retries: "{{ fyre_requestRetries }}"
     delay: 5

--- a/ansible/roles/fyrevm_provision/tasks/fyrevm_provision.yml
+++ b/ansible/roles/fyrevm_provision/tasks/fyrevm_provision.yml
@@ -86,7 +86,6 @@
     force_basic_auth: True
     validate_certs: False
     return_content: yes
-    body_format: json
   changed_when: false
   register: clusterStatus
   until: (clusterStatus.status == 200) and clusterStatus.json is defined and (clusterStatus.json[clusterName][0].status  == "deployed" or clusterStatus.json[clusterName][0].status == "error")

--- a/ansible/roles/request_ocp_fyre/tasks/request-ocp-fyre.yml
+++ b/ansible/roles/request_ocp_fyre/tasks/request-ocp-fyre.yml
@@ -88,7 +88,6 @@
     validate_certs: False
     password: "{{ fyreapikey }}"
     return_content: yes
-    body_format: json
     force_basic_auth: "{{ fyre_force_basic_auth }}"
   changed_when: false
   register: cluster_status_response
@@ -114,7 +113,6 @@
     validate_certs: False
     password: "{{ fyreapikey }}"
     return_content: yes
-    body_format: json
     force_basic_auth: "{{ fyre_force_basic_auth }}"
   changed_when: false
   register: cluster_details_response
@@ -126,12 +124,11 @@
   no_log: True
   uri:
     url: "{{fyre_opshowclusterurl}}"
-    method: POST
+    method: GET
     user:  "{{ fyreuser }}"
     validate_certs: False
     password: "{{ fyreapikey }}"
     return_content: yes
-    body_format: json
     force_basic_auth: "{{ fyre_force_basic_auth }}"
   changed_when: false
   register: all_user_clusters_response


### PR DESCRIPTION
We are causing fyre issues by sending a content-type of "application/json" without any JSON or sending a POST call with no data (when it should probably be a GET).

Where we request status from fyre, it should be a get not a POST and we are not sending any body, so we should avoid setting body_format. Setting body_format causes ansible to send json=null.

Fyre is looking to turn on "ModSecurity: Cannot add scalar value without an associated key" which would block such requests. We need to fix our code before fyre breaks us.
