### PR TITLE
Avoid downloading plays through ansible galaxy

### DIFF
--- a/ansible/galaxy.yml
+++ b/ansible/galaxy.yml
@@ -29,3 +29,7 @@ repository: "https://github.com/IBM/community-automation/tree/master/ansible"
 build_ignore: 
     - "*/roles" #Avoid cloning the roles symlinks
     - "*-play"
+    - "*_play"
+    - "install_instana_agent"
+    - "request-ocs-local-storage-vmware"
+    - "was-automation-register"

--- a/ansible/galaxy.yml
+++ b/ansible/galaxy.yml
@@ -26,3 +26,6 @@ license:
 #    - demo
 #    - collection
 repository: "https://github.com/IBM/community-automation/tree/master/ansible"
+build_ignore: 
+    - "*/roles" #Avoid cloning the roles symlinks
+    - "*-play"


### PR DESCRIPTION
Ansible galaxy doesnt understand symlink so the roles linked folder within each play cause us to download the same roles many times. Attempt to exclude all plays from galaxy install.