### PR TITLE
Installation and uninstallation of CPFS v4 in any namespace

### DIFF
--- a/ansible/roles/common_services/tasks/install.yml
+++ b/ansible/roles/common_services/tasks/install.yml
@@ -42,7 +42,7 @@
   delay: 30
 
 - name: Query available operands
-  shell: oc -n ibm-common-services get operandregistry common-service -o jsonpath='{.spec.operators[*].name}'
+  shell: oc -n {{ cs_operator_project_name }} get operandregistry common-service -o jsonpath='{.spec.operators[*].name}'
   register: oc_operands
 
 - name: Display available operands
@@ -62,43 +62,43 @@
 
 - name: Deploy generated OperandRequest
   shell: |
-    oc project ibm-common-services
-    oc -n ibm-common-services apply -f operandrequest.yml
+    oc project {{ cs_operator_project_name }}
+    oc -n {{ cs_operator_project_name }} apply -f operandrequest.yml
   args:
     chdir: "{{ cs_setup_dir }}"
 
 - name: Waiting for ClusterServiceVersion to initialize
   shell: |
     sleep 30
-    oc -n ibm-common-services get csv --no-headers | grep -v operand-deployment-lifecycle-manager | wc -l
+    oc -n {{ cs_operator_project_name }} get csv --no-headers | grep -v operand-deployment-lifecycle-manager | wc -l
   register: csvi_count
   until: csvi_count.stdout|int >= 1
   retries: 20
   delay: 30
 
 - name: Waiting for all ClusterServiceVersion to complete
-  shell: "sleep 30; oc -n ibm-common-services get csv --no-headers | grep -v Succeeded | wc -l"
+  shell: "sleep 30; oc -n {{ cs_operator_project_name }} get csv --no-headers | grep -v Succeeded | wc -l"
   register: csvc_count
   until: csvc_count.stdout|int == 0
   retries: 45
   delay: 30
 
 - name: Make sure Mongodb is present
-  shell: "sleep 30; oc -n ibm-common-services get statefulset --no-headers | grep -i mongodb | wc -l"
+  shell: "sleep 30; oc -n {{ cs_operator_project_name }} get statefulset --no-headers | grep -i mongodb | wc -l"
   register: mongo_count
   until: mongo_count.stdout|int != 0
   retries: 10
   delay: 30
 
 - name: Make sure all Statefulsets are healthy
-  shell: "sleep 30; oc -n ibm-common-services get statefulset --no-headers | egrep \"0/1|0/2|1/2|0/3|1/3|2/3\" | wc -l"
+  shell: "sleep 30; oc -n {{ cs_operator_project_name }} get statefulset --no-headers | egrep \"0/1|0/2|1/2|0/3|1/3|2/3\" | wc -l"
   register: statefulset_unhealthy
   until: statefulset_unhealthy.stdout|int == 0
   retries: 30
   delay: 30
 
 - name: Make sure all jobs are completed
-  shell: "sleep 30; oc -n ibm-common-services get job --no-headers | egrep \"0/1|0/2|1/2|0/3|1/3|2/3\" | wc -l"
+  shell: "sleep 30; oc -n {{ cs_operator_project_name }} get job --no-headers | egrep \"0/1|0/2|1/2|0/3|1/3|2/3\" | wc -l"
   register: job_notcompleted
   until: job_notcompleted.stdout|int == 0
   retries: 15
@@ -111,8 +111,8 @@
 
 - name: Query console admin password
   shell: |
-    oc -n ibm-common-services get route cp-console -o jsonpath='{.spec.host}'; echo
-    oc -n ibm-common-services get secret platform-auth-idp-credentials -o jsonpath='{.data.admin_password}' | base64 -d
+    oc -n {{ cs_operator_project_name }} get route cp-console -o jsonpath='{.spec.host}'; echo
+    oc -n {{ cs_operator_project_name }} get secret platform-auth-idp-credentials -o jsonpath='{.data.admin_password}' | base64 -d
   register: cs_admin_password
 
 - name: Display console admin password

--- a/ansible/roles/common_services/tasks/main.yml
+++ b/ansible/roles/common_services/tasks/main.yml
@@ -33,7 +33,7 @@
 
 - name: Get openshift projects
   debug:
-    msg: "{{ ocp_projects.stdout.find('ibm-common-services') }}"
+    msg: "{{ ocp_projects.stdout.find('{{ cs_operator_project_name }}') }}"
 
 - include_tasks: "uninstall.yml"
   when: cs_action == "uninstall"

--- a/ansible/roles/common_services/tasks/uninstall.yml
+++ b/ansible/roles/common_services/tasks/uninstall.yml
@@ -2,68 +2,68 @@
 # tasks file cp4 common services uninstall
 
 - name: uninstall - removing operandrequest/common-service
-  when: ocp_projects.stdout.find('ibm-common-services') != -1
+  when: ocp_projects.stdout.find('{{ cs_operator_project_name }}') != -1
   shell: |
-    oc -n ibm-common-services delete operandrequest {{ cs_operator_project_name }} || true
+    oc -n {{ cs_operator_project_name }} delete operandrequest {{ cs_operator_project_name }} || true
 
 - name: uninstall - removing operandrequests
-  when: ocp_projects.stdout.find('ibm-common-services') != -1
+  when: ocp_projects.stdout.find('{{ cs_operator_project_name }}') != -1
   shell: |
     if [[ ! -z "$(oc get crd | grep operandrequests)" ]]; then
-      for request in $(oc -n ibm-common-services get operandrequests -o name); do
+      for request in $(oc -n {{ cs_operator_project_name }} get operandrequests -o name); do
         echo "Deleting ${request} ..."
-        oc -n ibm-common-services delete ${request} --ignore-not-found --timeout=60s
+        oc -n {{ cs_operator_project_name }} delete ${request} --ignore-not-found --timeout=60s
       done
-      for request in $(oc -n ibm-common-services get operandrequests -o name); do
+      for request in $(oc -n {{ cs_operator_project_name }} get operandrequests -o name); do
         echo "Force deleting ${request} ..."        
-        oc -n ibm-common-services patch ${request} --type="json" -p '[{"op": "remove", "path":"/metadata/finalizers"}]'
-        oc -n ibm-common-services delete ${request} --ignore-not-found --timeout=10s
+        oc -n {{ cs_operator_project_name }} patch ${request} --type="json" -p '[{"op": "remove", "path":"/metadata/finalizers"}]'
+        oc -n {{ cs_operator_project_name }} delete ${request} --ignore-not-found --timeout=10s
       done
     fi
 
 - name: uninstall - removing CRs
-  when: ocp_projects.stdout.find('ibm-common-services') != -1
+  when: ocp_projects.stdout.find('{{ cs_operator_project_name }}') != -1
   shell: |
     if [[ ! -z "$(oc get crd | grep operator.ibm.com)" ]]; then
       for crd in $(oc get crd | grep operator.ibm.com | awk '{print $1}'); do
         echo "Checking remaining CRs for ${crd} ..."
-        for cr in $(oc -n ibm-common-services get ${crd} -o name); do
+        for cr in $(oc -n {{ cs_operator_project_name }} get ${crd} -o name); do
             echo "Deleting CR ${cr} ..."
-            oc -n ibm-common-services delete ${cr} --ignore-not-found --timeout=30s
+            oc -n {{ cs_operator_project_name }} delete ${cr} --ignore-not-found --timeout=30s
         done
-        for cr in $(oc -n ibm-common-services get ${crd} -o name); do
+        for cr in $(oc -n {{ cs_operator_project_name }} get ${crd} -o name); do
             echo "Force deleting CR ${cr} ..."
-            oc -n ibm-common-services patch ${cr} --type json -p '[{ "op": "remove", "path": "/metadata/finalizers"}]'
-            oc -n ibm-common-services delete ${cr} --ignore-not-found --timeout=10s
+            oc -n {{ cs_operator_project_name }} patch ${cr} --type json -p '[{ "op": "remove", "path": "/metadata/finalizers"}]'
+            oc -n {{ cs_operator_project_name }} delete ${cr} --ignore-not-found --timeout=10s
         done
       done
     fi
 
 - name: uninstall - validate CRs removal
-  when: ocp_projects.stdout.find('ibm-common-services') != -1
+  when: ocp_projects.stdout.find('{{ cs_operator_project_name }}') != -1
   shell: |
-    oc -n ibm-common-services get --no-headers operandrequest | wc -l
+    oc -n {{ cs_operator_project_name }} get --no-headers operandrequest | wc -l
   register: operand_requests
   until: operand_requests.stdout|int == 0
   retries: 10
   delay: 10
 
 - name: uninstall - remove operandconfig and operandregistry
-  when: ocp_projects.stdout.find('ibm-common-services') != -1
+  when: ocp_projects.stdout.find('{{ cs_operator_project_name }}') != -1
   shell: |
-    oc -n ibm-common-services delete operandconfig {{ cs_operator_project_name }} || true
-    oc -n ibm-common-services delete operandregistry {{ cs_operator_project_name }} || true
+    oc -n {{ cs_operator_project_name }} delete operandconfig {{ cs_operator_project_name }} || true
+    oc -n {{ cs_operator_project_name }} delete operandregistry {{ cs_operator_project_name }} || true
 
 - name: uninstall - removing operators csv and subscriptions
-  when: ocp_projects.stdout.find('ibm-common-services') != -1
+  when: ocp_projects.stdout.find('{{ cs_operator_project_name }}') != -1
   shell: |
-    oc -n ibm-common-services get csv,sub -o name | grep -v operand-deployment-lifecycle-manager | grep -v ibm-common-service-operator | while read CSTARGET; do
+    oc -n {{ cs_operator_project_name }} get csv,sub -o name | grep -v operand-deployment-lifecycle-manager | grep -v ibm-common-service-operator | while read CSTARGET; do
       echo removing $CSTARGET
-      oc -n ibm-common-services delete $CSTARGET --ignore-not-found --timeout=5s
+      oc -n {{ cs_operator_project_name }} delete $CSTARGET --ignore-not-found --timeout=5s
     done
 
 - name: uninstall - removing cluster resources
-  when: ocp_projects.stdout.find('ibm-common-services') != -1
+  when: ocp_projects.stdout.find('{{ cs_operator_project_name }}') != -1
   shell: |
     oc delete --ignore-not-found=true --timeout=10s validatingwebhookconfiguration.admissionregistration.k8s.io/cert-manager-webhook
     oc delete --ignore-not-found=true --timeout=10s mutatingwebhookconfiguration.admissionregistration.k8s.io/ibm-common-service-webhook-configuration
@@ -71,26 +71,26 @@
     oc delete --ignore-not-found=true --timeout=10s securitycontextconstraints.security.openshift.io/nginx-ingress-scc
 
 - name: uninstall - remove ODLM 
-  when: ocp_projects.stdout.find('ibm-common-services') != -1
+  when: ocp_projects.stdout.find('{{ cs_operator_project_name }}') != -1
   shell: |
     for resource in $(oc -n openshift-operators get csv,sub -o name --ignore-not-found | grep operand-deployment-lifecycle-manager); do
       oc -n openshift-operators delete ${resource} --ignore-not-found --timeout=30s
     done
-    for resource in $(oc -n ibm-common-services get csv,sub -o name --ignore-not-found | grep operand-deployment-lifecycle-manager); do
-      oc -n ibm-common-services delete ${resource} --ignore-not-found --timeout=30s
+    for resource in $(oc -n {{ cs_operator_project_name }} get csv,sub -o name --ignore-not-found | grep operand-deployment-lifecycle-manager); do
+      oc -n {{ cs_operator_project_name }} delete ${resource} --ignore-not-found --timeout=30s
     done
-    for plan in $(oc -n ibm-common-services get installplans -o name); do
+    for plan in $(oc -n {{ cs_operator_project_name }} get installplans -o name); do
       echo "Deleting ${plan} ..."
-      oc -n ibm-common-services delete ${plan} --ignore-not-found --timeout=10s
+      oc -n {{ cs_operator_project_name }} delete ${plan} --ignore-not-found --timeout=10s
     done
 
 - name: uninstall - remove catalog source
-  when: ocp_projects.stdout.find('ibm-common-services') != -1
+  when: ocp_projects.stdout.find('{{ cs_operator_project_name }}') != -1
   shell: |
     oc -n openshift-marketplace delete catalogsource opencloud-operators --ignore-not-found --timeout=10s
 
 - name: uninstall - remove common service operator 
-  when: ocp_projects.stdout.find('ibm-common-services') != -1
+  when: ocp_projects.stdout.find('{{ cs_operator_project_name }}') != -1
   shell: |
     if [[ ! -z "$(oc get ns {{ cs_operator_project_name }} --no-headers --ignore-not-found)" ]]; then
         oc -n {{ cs_operator_project_name }} get csv -o name | grep ibm-common-service-operator | xargs oc -n {{ cs_operator_project_name }} delete --timeout=30s
@@ -102,7 +102,7 @@
     fi
 
 - name: uninstall - remove RBAC resource
-  when: ocp_projects.stdout.find('ibm-common-services') != -1
+  when: ocp_projects.stdout.find('{{ cs_operator_project_name }}') != -1
   shell: |
     oc delete ClusterRole ibm-common-service-webhook --ignore-not-found
     oc delete ClusterRoleBinding ibm-common-service-webhook --ignore-not-found
@@ -111,20 +111,8 @@
     oc delete RoleBinding ibmcloud-cluster-ca-cert -n kube-public --ignore-not-found
     oc delete Role ibmcloud-cluster-ca-cert -n kube-public --ignore-not-found
 
-- name: uninstall - cleaning up project ibm-common-services
-  when: ocp_projects.stdout.find('ibm-common-services') != -1
-  shell: |
-    for CSTARGET in $(oc -n ibm-common-services get sub,csv -o name); do
-      echo removing $CSTARGET
-      oc -n ibm-common-services delete $CSTARGET --ignore-not-found --timeout=20s
-    done
-    for CSTARGET in $(oc -n ibm-common-services get all -o name); do
-      echo removing $CSTARGET
-      oc -n ibm-common-services delete $CSTARGET --ignore-not-found --timeout=20s
-    done
-
-- name: uninstall - cleaning up project common-service
-  when: ocp_projects.stdout.find('ibm-common-services') != -1
+- name: uninstall - cleaning up project {{ cs_operator_project_name }}
+  when: ocp_projects.stdout.find('{{ cs_operator_project_name }}') != -1
   shell: |
     for CSTARGET in $(oc -n {{ cs_operator_project_name }} get sub,csv -o name); do
       echo removing $CSTARGET
@@ -135,13 +123,25 @@
       oc -n {{ cs_operator_project_name }} delete $CSTARGET --ignore-not-found --timeout=20s
     done
 
-- name: uninstall - delete projects {{ cs_operator_project_name }} and ibm-common-services
-  when: ocp_projects.stdout.find('ibm-common-services') != -1
+- name: uninstall - cleaning up project common-service
+  when: ocp_projects.stdout.find('{{ cs_operator_project_name }}') != -1
   shell: |
-      oc delete project {{ cs_operator_project_name }} ibm-common-services --ignore-not-found
+    for CSTARGET in $(oc -n {{ cs_operator_project_name }} get sub,csv -o name); do
+      echo removing $CSTARGET
+      oc -n {{ cs_operator_project_name }} delete $CSTARGET --ignore-not-found --timeout=20s
+    done
+    for CSTARGET in $(oc -n {{ cs_operator_project_name }} get all -o name); do
+      echo removing $CSTARGET
+      oc -n {{ cs_operator_project_name }} delete $CSTARGET --ignore-not-found --timeout=20s
+    done
+
+- name: uninstall - delete projects {{ cs_operator_project_name }} and {{ cs_operator_project_name }}
+  when: ocp_projects.stdout.find('{{ cs_operator_project_name }}') != -1
+  shell: |
+      oc delete project {{ cs_operator_project_name }} {{ cs_operator_project_name }} --ignore-not-found
 
 - name: uninstall - validate projects removal
-  when: ocp_projects.stdout.find('ibm-common-services') != -1
+  when: ocp_projects.stdout.find('{{ cs_operator_project_name }}') != -1
   shell: |
     oc projects | grep {{ cs_operator_project_name }} | wc -l
   register: cs_projects

--- a/ansible/roles/common_services/templates/cs-request.bash.j2
+++ b/ansible/roles/common_services/templates/cs-request.bash.j2
@@ -11,14 +11,14 @@ apiVersion: operator.ibm.com/v1alpha1
 kind: OperandRequest
 metadata:
   name: common-service
-  namespace: ibm-common-services
+  namespace: {{ cs_operator_project_name }}
 spec:
   requests:
   - registry: common-service
-    registryNamespace: ibm-common-services
+    registryNamespace: {{ cs_operator_project_name }}
     operands:
 ENDF
-   for operand in `oc -n ibm-common-services get operandregistry common-service -o jsonpath='{.spec.operators[?(@.sourceName=="opencloud-operators")].name}'`; do
+   for operand in `oc -n {{ cs_operator_project_name }} get operandregistry common-service -o jsonpath='{.spec.operators[?(@.sourceName=="opencloud-operators")].name}'`; do
       if [ "X$OPERANDS_TO_DISABLE" != "X" ]; then
          if echo $operand | egrep -q "$OPERANDS_TO_DISABLE"; then
             echo "    # - name: $operand"

--- a/ansible/roles/common_services/templates/cs-request.yaml.j2
+++ b/ansible/roles/common_services/templates/cs-request.yaml.j2
@@ -2,7 +2,7 @@ apiVersion: operator.ibm.com/v1alpha1
 kind: OperandRequest
 metadata:
  name: common-service
- namespace: ibm-common-services
+ namespace: {{ cs_operator_project_name }}
 spec:
  requests:
    - operands:

--- a/ansible/roles/common_services/templates/cs-validation.bash.j2
+++ b/ansible/roles/common_services/templates/cs-validation.bash.j2
@@ -5,7 +5,7 @@ declare -i ROUND=0
 declare -i count_sub=0
 declare -i count_csv=0
 strict_validation={{ strict_validation }}
-NAMESPACE=ibm-common-services
+NAMESPACE={{ cs_operator_project_name }}
 NAMESPACE_ODLM={{ cs_operator_project_name }}
 
 # check statefulsets to make sure running normal


### PR DESCRIPTION
- The CPFS v4 documentation suggests that we can install it in any namespace and it is not mandatory to have the **ibm-common-services** namespace tightly coupled with the CPFS installation.
- Introduced variable **cs_operator_project_name** where ever the namespace was hardcoded to be **ibm-common-services**