### PR TITLE
Fix: typo in contribution guidelines

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,7 +2,7 @@
 
 ## IMPORTANT
 
-When developing automation that needs to be kept private, do so in a private repository that consumes the roles from this public community repository.  This can be done using collections or by referncing the roles in your own playbooks.  See readme for details.
+When developing automation that needs to be kept private, do so in a private repository that consumes the roles from this public community repository.  This can be done using collections or by referencing the roles in your own playbooks.  See readme for details.
  
 To contribute code or documentation, create a fork, operate on your fork, and put in a [pull request](https://github.com/IBM/community-automation/pulls).
 


### PR DESCRIPTION
Corrected the typo "referncing" to "referencing" in the IMPORTANT section of the contribution guidelines.