### PR TITLE
Remove unnecessary python3 install

### DIFF
--- a/ansible/csi-cephfs-fyre-play/csi-cephfs.yml
+++ b/ansible/csi-cephfs-fyre-play/csi-cephfs.yml
@@ -3,9 +3,6 @@
   hosts: bastion
   gather_facts: no
   tasks:
-  - name: python_install_fyre
-    include_role:
-      name: python_install_fyre
   - name: Gathering Facts
     setup:
   - name: git_install_fyre


### PR DESCRIPTION
The Fyre inf nodes are now using RHEL9, which means that Python3 is already installed.